### PR TITLE
Fix mismatch in "EFIAPI" ABI for PeiCore function

### DIFF
--- a/IntelFsp2Pkg/FspSecCore/SecMain.h
+++ b/IntelFsp2Pkg/FspSecCore/SecMain.h
@@ -24,9 +24,9 @@
 #include <Library/UefiCpuLib.h>
 #include <FspEas.h>
 
-typedef VOID (*PEI_CORE_ENTRY) ( \
-  IN CONST  EFI_SEC_PEI_HAND_OFF    *SecCoreData, \
-  IN CONST  EFI_PEI_PPI_DESCRIPTOR  *PpiList \
+typedef VOID (EFIAPI *PEI_CORE_ENTRY) (
+  IN CONST  EFI_SEC_PEI_HAND_OFF    *SecCoreData,
+  IN CONST  EFI_PEI_PPI_DESCRIPTOR  *PpiList
 );
 
 typedef struct _SEC_IDT_TABLE {


### PR DESCRIPTION
The caller declaration (PeiCore) did not use "EFIAPI" while the callee
declaration (_ModuleEntryPoint) does use "EFIAPI".

See the declaration of the callee in
MdePkg\Library\PeiCoreEntryPoint\PeiCoreEntryPoint.c:

	VOID EFIAPI _ModuleEntryPoint(
	  IN CONST EFI_SEC_PEI_HAND_OFF *SecCoreData,
	  IN CONST EFI_PEI_PPI_DESCRIPTOR *PpiList
	);

Note the callee and caller are linked together at compile time with a
patch script.

How did this work before? I do not know.

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>